### PR TITLE
Add an Agent class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CXX          ?= g++
 CXXOPTS      ?= -g -Wall -Werror -std=c++11 -Iinclude/ -Ideps/url-cpp/include
-DEBUG_OPTS   ?= -fprofile-arcs -ftest-coverage -O0 -fPIC -Ldeps/url-cpp/debug
-RELEASE_OPTS ?= -O3 -Ldeps/url-cpp/release
+DEBUG_OPTS   ?= -fprofile-arcs -ftest-coverage -O0 -fPIC
+RELEASE_OPTS ?= -O3
 BINARIES      = 
 
 all: test release/librep.o $(BINARIES)
@@ -13,7 +13,7 @@ release:
 release/bin: release
 	mkdir -p release/bin
 
-release/librep.o: release/directive.o
+release/librep.o: release/directive.o release/agent.o deps/url-cpp/release/liburl.o
 	ld -r -o $@ $^
 
 release/%.o: src/%.cpp include/%.h release
@@ -26,7 +26,7 @@ debug:
 debug/bin: debug
 	mkdir -p debug/bin
 
-debug/librep.o: debug/directive.o
+debug/librep.o: debug/directive.o debug/agent.o deps/url-cpp/debug/liburl.o
 	ld -r -o $@ $^
 
 debug/%.o: src/%.cpp include/%.h debug
@@ -36,7 +36,7 @@ test/%.o: test/%.cpp
 	$(CXX) $(CXXOPTS) $(DEBUG_OPTS) -o $@ -c $<
 
 # Tests
-test-all: test/test-all.o test/test-directive.o debug/librep.o
+test-all: test/test-all.o test/test-agent.o test/test-directive.o debug/librep.o
 	$(CXX) $(CXXOPTS) $(DEBUG_OPTS) -o $@ $^ -lgtest -lpthread
 
 # Bench

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ release:
 release/bin: release
 	mkdir -p release/bin
 
+deps/url-cpp/release/liburl.o: deps/url-cpp/* deps/url-cpp/include/* deps/url-cpp/src/*
+	make -C deps/url-cpp release/liburl.o
+
 release/librep.o: release/directive.o release/agent.o deps/url-cpp/release/liburl.o
 	ld -r -o $@ $^
 
@@ -25,6 +28,9 @@ debug:
 
 debug/bin: debug
 	mkdir -p debug/bin
+
+deps/url-cpp/debug/liburl.o: deps/url-cpp/* deps/url-cpp/include/* deps/url-cpp/src/*
+	make -C deps/url-cpp debug/liburl.o
 
 debug/librep.o: debug/directive.o debug/agent.o deps/url-cpp/debug/liburl.o
 	ld -r -o $@ $^
@@ -49,4 +55,4 @@ test: test-all
 	./scripts/check-coverage.sh $(PWD)
 
 clean:
-	rm -rf debug release test-all bench
+	rm -rf debug release test-all bench test/*.o deps/url-cpp/{debug,release}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CXX          ?= g++
-CXXOPTS      ?= -g -Wall -Werror -std=c++11 -Iinclude/ -Ideps/url-cpp/include
-DEBUG_OPTS   ?= -fprofile-arcs -ftest-coverage -O0 -fPIC
+CXXOPTS      ?= -Wall -Werror -std=c++11 -Iinclude/ -Ideps/url-cpp/include
+DEBUG_OPTS   ?= -g -fprofile-arcs -ftest-coverage -O0 -fPIC
 RELEASE_OPTS ?= -O3
 BINARIES      = 
 

--- a/include/agent.h
+++ b/include/agent.h
@@ -1,0 +1,68 @@
+#ifndef AGENT_CPP_H
+#define AGENT_CPP_H
+
+#include <vector>
+
+#include "directive.h"
+
+
+namespace Rep
+{
+
+    class Agent
+    {
+    public:
+        /* The type for the delay. */
+        typedef float delay_t;
+
+        /**
+         * Construct an agent.
+         */
+        Agent(): directives_(), delay_(-1.0), sorted_(true) {}
+
+        /**
+         * Add an allowed directive.
+         */
+        Agent& allow(const std::string& query);
+
+        /**
+         * Add a disallowed directive.
+         */
+        Agent& disallow(const std::string& query);
+
+        /**
+         * Set the delay for this agent.
+         */
+        Agent& delay(delay_t value) {
+            delay_ = value;
+            return *this;
+        }
+
+        /**
+         * Return the delay for this agent.
+         */
+        delay_t delay() const { return delay_; }
+
+        /**
+         * A vector of the directives, in priority-sorted order.
+         */
+        const std::vector<Directive>& directives() const;
+
+        /**
+         * Return true if the URL (either a full URL or a path) is allowed.
+         */
+        bool allowed(const std::string& path) const;
+
+        /**
+         * Canonically escape the provided query for matching purposes.
+         */
+        static std::string escape(const std::string& query);
+
+    private:
+        mutable std::vector<Directive> directives_;
+        delay_t delay_;
+        mutable bool sorted_;
+    };
+}
+
+#endif

--- a/test/test-agent.cpp
+++ b/test/test-agent.cpp
@@ -1,0 +1,70 @@
+#include <gtest/gtest.h>
+
+#include "agent.h"
+
+TEST(AgentTest, Basic)
+{
+    Rep::Agent agent = Rep::Agent().allow("/").disallow("/foo");
+    EXPECT_EQ(agent.directives().size(), 2);
+}
+
+TEST(AgentTest, ChecksAllowed)
+{
+    Rep::Agent agent = Rep::Agent().allow("/path");
+    EXPECT_TRUE(agent.allowed("/path"));
+    EXPECT_TRUE(agent.allowed("/elsewhere"));
+}
+
+TEST(AgentTest, HonorsLongestFirstPriority)
+{
+    Rep::Agent agent = Rep::Agent().disallow("/path").allow("/path/exception");
+    EXPECT_TRUE(agent.allowed("/path/exception"));
+    EXPECT_FALSE(agent.allowed("/path"));
+}
+
+TEST(AgentTest, RobotsTextAllowed)
+{
+    Rep::Agent agent = Rep::Agent().disallow("/robots.txt");
+    EXPECT_TRUE(agent.allowed("/robots.txt"));
+}
+
+TEST(AgentTest, DisallowNone)
+{
+    Rep::Agent agent = Rep::Agent().disallow("");
+    EXPECT_TRUE(agent.allowed("/anything"));
+}
+
+TEST(AgentTest, EscapedRule)
+{
+    Rep::Agent agent = Rep::Agent().disallow("/a%3cd.html");
+    EXPECT_FALSE(agent.allowed("/a<d.html"));
+    EXPECT_FALSE(agent.allowed("/a%3cd.html"));
+}
+
+TEST(AgentTest, UnescapedRule)
+{
+    Rep::Agent agent = Rep::Agent().disallow("/a<d.html");
+    EXPECT_FALSE(agent.allowed("/a<d.html"));
+    EXPECT_FALSE(agent.allowed("/a%3cd.html"));
+}
+
+TEST(AgentTest, EscapedRuleWildcard)
+{
+    Rep::Agent agent = Rep::Agent().disallow("/a%3c*");
+    EXPECT_FALSE(agent.allowed("/a<d.html"));
+    EXPECT_FALSE(agent.allowed("/a%3cd.html"));
+}
+
+TEST(AgentTest, UnescapedRuleWildcard)
+{
+    Rep::Agent agent = Rep::Agent().disallow("/a<*");
+    EXPECT_FALSE(agent.allowed("/a<d.html"));
+    EXPECT_FALSE(agent.allowed("/a%3cd.html"));
+}
+
+TEST(AgentTest, AcceptsFullUrl)
+{
+    Rep::Agent agent = Rep::Agent().disallow("/path;params?query");
+    EXPECT_FALSE(agent.allowed(
+        "http://userinfo@exmaple.com:10/path;params?query#fragment"));
+}


### PR DESCRIPTION
The `Agent` class holds all user-agent-specific information, including the crawl-delay for the agent (if any), and the `Directive`s associated with that agent.

A path may match multiple directives, so the most-specific (i.e. longest) directive wins. For example, `/some/path/page.html` matches all of these rules:

```
Allow: /some/
Disallow: /some/path/
Allow: /*/page.html
```

As such, `/some/path/page.html` would be allowed because the `/*/page.html` rule is the longest.

Rather than finding all directives that match a query and having the highest priority one win, the `Directive`s in an `Agent` are sorted (lazily), so that we just have to traverse them until we find a match, and that is the winner. Future implementations might try to do something fancier, like a prefix trie, but I imagine that's far more trouble than it's worth.

This relates to https://github.com/seomoz/url-cpp/pull/28

@b4hand @arora-richa @tammybailey 
