### PR TITLE
Remove redundant escaping in allowed check.

### DIFF
--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -50,10 +50,9 @@ namespace Rep
             return true;
         }
 
-        std::string escaped = escape(path);
         for (auto directive : directives())
         {
-            if (directive.match(escaped))
+            if (directive.match(path))
             {
                 return directive.allowed();
             }


### PR DESCRIPTION
@b4hand @tammybailey @lindseyreno 

During some refactoring, I left this redundant call to `escape`.

![](http://picturethis.dk/i.php?/upload/2013/01/10/20130110194646-bb76c520-la.jpg)