### PR TITLE
Add `Rep::Robots::robotsUrl`

### DIFF
--- a/include/robots.h
+++ b/include/robots.h
@@ -46,6 +46,11 @@ namespace Rep
          */
         bool allowed(const std::string& path, const std::string& name) const;
 
+        /**
+         * Return the robots.txt URL corresponding to the provided URL.
+         */
+        static std::string robotsUrl(const std::string& url);
+
     private:
         static void strip(std::string& string);
 

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -17,6 +17,7 @@ results=`gcovr \
     --print-summary \
     --object-directory=${root} \
     --exclude test \
+    --exclude deps/ \
     --exclude src/psl.cpp \
     --exclude src/punycode.cpp \
     --exclude src/url.cpp \

--- a/src/robots.cpp
+++ b/src/robots.cpp
@@ -6,6 +6,8 @@
 #include <iostream>
 #include <unordered_map>
 
+#include "url.h"
+
 #include "robots.h"
 
 namespace Rep
@@ -159,5 +161,17 @@ namespace Rep
     bool Robots::allowed(const std::string& path, const std::string& name) const
     {
         return agent(name).allowed(path);
+    }
+
+    std::string Robots::robotsUrl(const std::string& url)
+    {
+        return Url::Url(url)
+            .setUserinfo("")
+            .setPath("robots.txt")
+            .setParams("")
+            .setQuery("")
+            .setFragment("")
+            .remove_default_port()
+            .str();
     }
 }

--- a/test/test-robots.cpp
+++ b/test/test-robots.cpp
@@ -165,6 +165,28 @@ TEST(RobotsTest, SkipMalformedLine)
     EXPECT_TRUE(robot.allowed("/no/colon/in/this/line", "agent"));
 }
 
+TEST(RobotsTest, RobotsUrlHttp)
+{
+    std::string url("http://user@example.com:80/path;params?query#fragment");
+    std::string expected("http://example.com/robots.txt");
+    EXPECT_EQ(expected, Rep::Robots::robotsUrl(url));
+}
+
+TEST(RobotsTest, RobotsUrlHttps)
+{
+    std::string url("https://user@example.com:443/path;params?query#fragment");
+    std::string expected("https://example.com/robots.txt");
+    EXPECT_EQ(expected, Rep::Robots::robotsUrl(url));
+}
+
+TEST(RobotsTest, RobotsUrlNonDefaultPort)
+{
+    std::string url("http://user@example.com:8080/path;params?query#fragment");
+    std::string expected("http://example.com:8080/robots.txt");
+    EXPECT_EQ(expected, Rep::Robots::robotsUrl(url));
+}
+
+
 TEST(RobotsTest, RfcExample)
 {
     std::string content =


### PR DESCRIPTION
A helper utility to go from `http://userinfo@example.com:80/path;params?query#fragment` to `http://example.com/robots.txt`

@b4hand @arora-richa @neilmb 