### PR TITLE
Support a query-only directive

### DIFF
--- a/test/test-agent.cpp
+++ b/test/test-agent.cpp
@@ -68,3 +68,17 @@ TEST(AgentTest, AcceptsFullUrl)
     EXPECT_FALSE(agent.allowed(
         "http://userinfo@exmaple.com:10/path;params?query#fragment"));
 }
+
+TEST(AgentTest, QueryOnly)
+{
+    Rep::Agent agent = Rep::Agent().disallow("/?");
+    EXPECT_TRUE(agent.allowed("/"));
+    EXPECT_FALSE(agent.allowed("/?query"));
+}
+
+TEST(AgentTest, ParamsOnly)
+{
+    Rep::Agent agent = Rep::Agent().disallow("/;");
+    EXPECT_TRUE(agent.allowed("/"));
+    EXPECT_FALSE(agent.allowed("/;params"));
+}


### PR DESCRIPTION
We encountered this case recently (and I imagine it's fairly common), where the host wanted to disable all requests that had a query. That's specified with `/?`, but previously `url-cpp` was automatically canonicalizing that to `/`, which disallows all.

This is a partner PR to https://github.com/seomoz/url-cpp/pull/29

@b4hand @neilmb @tammybailey 