### PR TITLE
Build against both clang and gcc.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: required
 dist: trusty
 git:
   submodules: true
+compiler:
+  - gcc
+  - clang
 language: cpp
 before_install: scripts/travis/before_install.sh
 script: make test

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -30,7 +30,10 @@ results=`gcovr \
 lines=`echo ${results} | sed -E 's#^.*lines: ([0-9]+)(\.[0-9]+)?%.+$#\1#'`
 branches=`echo ${results} | sed -E 's#^.*branches: ([0-9]+)(\.[0-9]+)?%.+$#\1#'`
 
-if [ "${lines}" -ne "100" ]; then
+if [ "${lines}" -eq "0" ]; then
+    echo "Coverage disabled."
+    echo "#{results}"
+elif [ "${lines}" -ne "100" ]; then
     echo "Incomplete line coverage (${lines})"
     echo "${results}"
     exit 2


### PR DESCRIPTION
Some people are having difficulty building `reppy` on OS X, and it comes down to a `clang` error. Hopefully this will expose the issue and allow us to debug.