### PR TITLE
Handle invalid port numbers

### DIFF
--- a/test/test-robots.cpp
+++ b/test/test-robots.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include "url.h"
+
 #include "robots.h"
 
 TEST(RobotsTest, NoLeadingUserAgent)
@@ -179,6 +181,12 @@ TEST(RobotsTest, RobotsUrlNonDefaultPort)
     std::string url("http://user@example.com:8080/path;params?query#fragment");
     std::string expected("http://example.com:8080/robots.txt");
     EXPECT_EQ(expected, Rep::Robots::robotsUrl(url));
+}
+
+TEST(RobotsTest, RobotsUrlInvalidPort)
+{
+    std::string url("http://:::cnn.com/");
+    ASSERT_THROW(Rep::Robots::robotsUrl(url), Url::UrlParseException);
 }
 
 TEST(RobotsTest, RfcExample)


### PR DESCRIPTION
Currently, rep-cpp doesn't wrap any exceptions in its own class, so I'm just letting this exception from url-cpp propagate up.

This is related to seomoz/reppy#46.