### PR TITLE
Vendor in google test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Binaries and build artifacts
 *.o
+*.a
 bench
 test-all
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "deps/url-cpp"]
 	path = deps/url-cpp
 	url = https://github.com/seomoz/url-cpp
+[submodule "deps/googletest"]
+	path = deps/googletest
+	url = https://github.com/google/googletest/
+	ignore = untracked

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
+GTEST_DIR    ?= deps/googletest/googletest
+
 CXX          ?= g++
-CXXOPTS      ?= -Wall -Werror -std=c++11 -Iinclude/ -Ideps/url-cpp/include
+CXXOPTS      ?= -Wall -Werror -std=c++11 -Iinclude/ -Ideps/url-cpp/include -I$(GTEST_DIR)/include
 DEBUG_OPTS   ?= -g -fprofile-arcs -ftest-coverage -O0 -fPIC
 RELEASE_OPTS ?= -O3
-BINARIES      = 
+BINARIES      =
 
 all: test release/librep.o $(BINARIES)
+
+$(GTEST_DIR)/libgtest.a:
+	g++ -isystem $(GTEST_DIR)/include -I$(GTEST_DIR) -pthread -c $(GTEST_DIR)/src/gtest-all.cc -o $(GTEST_DIR)/libgtest.a
 
 # Release libraries
 release:
@@ -42,8 +47,8 @@ test/%.o: test/%.cpp
 	$(CXX) $(CXXOPTS) $(DEBUG_OPTS) -o $@ -c $<
 
 # Tests
-test-all: test/test-all.o test/test-agent.o test/test-directive.o test/test-robots.o debug/librep.o
-	$(CXX) $(CXXOPTS) $(DEBUG_OPTS) -o $@ $^ -lgtest -lpthread
+test-all: test/test-all.o test/test-agent.o test/test-directive.o test/test-robots.o debug/librep.o $(GTEST_DIR)/libgtest.a
+	$(CXX) $(CXXOPTS) -L$(GTEST_DIR) $(DEBUG_OPTS) -o $@ $^ -lpthread
 
 # Bench
 bench: bench.cpp release/librep.o

--- a/scripts/travis/before_install.sh
+++ b/scripts/travis/before_install.sh
@@ -5,12 +5,3 @@ set -e
 sudo apt-get install -y g++ libgtest-dev cmake python-pip
 
 sudo pip install gcovr==3.2
-
-pushd /tmp
-    mkdir -p gtest-build
-    pushd gtest-build
-        cmake -DCMAKE_BUILD_TYPE=RELEASE /usr/src/gtest/
-        make
-        find . -name 'libg*.a' | xargs sudo cp -f --target-directory=/usr/lib/
-    popd
-popd


### PR DESCRIPTION
In taking a look at #23 , I found that I didn't have `gtest`. Apparently the guidance now is to vendor in `gtest` for each project that uses (TIL that it's really quite easy and has no `cmake` dep), so this is what that PR aims to do with a submodule.

@b4hand