### PR TITLE
Ignore Allow/Disallow directives with external URLs.

### DIFF
--- a/include/agent.h
+++ b/include/agent.h
@@ -5,10 +5,14 @@
 
 #include "directive.h"
 
+// forward declaration
+namespace Url
+{
+    class Url;
+}
 
 namespace Rep
 {
-
     class Agent
     {
     public:
@@ -18,7 +22,8 @@ namespace Rep
         /**
          * Construct an agent.
          */
-        Agent() : directives_(), delay_(-1.0), sorted_(true) {}
+        explicit Agent(const std::string& host) :
+            directives_(), delay_(-1.0), sorted_(true), host_(host) {}
 
         /**
          * Add an allowed directive.
@@ -55,15 +60,13 @@ namespace Rep
 
         std::string str() const;
 
-        /**
-         * Canonically escape the provided query for matching purposes.
-         */
-        static std::string escape(const std::string& query);
-
     private:
+        bool is_external(const Url::Url& url) const;
+
         mutable std::vector<Directive> directives_;
         delay_t delay_;
         mutable bool sorted_;
+        std::string host_;
     };
 }
 

--- a/include/robots.h
+++ b/include/robots.h
@@ -19,17 +19,13 @@ namespace Rep
         /**
          * Create a robots.txt from a utf-8-encoded string.
          */
-        Robots(const std::string& content);
+        explicit Robots(const std::string& content);
 
         /**
-         * Instantiate a Robots object.
+         * Create a robots.txt from a utf-8-encoded string assuming
+         * the given base_url.
          */
-        Robots(
-            const agent_map_t& agents,
-            const sitemaps_t& sitemaps)
-            : agents_(agents)
-            , sitemaps_(sitemaps)
-            , default_(agents_["*"]) {}
+        Robots(const std::string& content, const std::string& base_url);
 
         /**
          * Get the sitemaps in this robots.txt
@@ -60,6 +56,7 @@ namespace Rep
         static bool getpair(
             std::istringstream& stream, std::string& key, std::string& value);
 
+        std::string host_;
         agent_map_t agents_;
         sitemaps_t sitemaps_;
         Agent& default_;

--- a/src/robots.cpp
+++ b/src/robots.cpp
@@ -54,9 +54,15 @@ namespace Rep
     }
 
     Robots::Robots(const std::string& content) :
+        Robots(content, "")
+    {
+    }
+
+    Robots::Robots(const std::string& content, const std::string& base_url) :
+        host_(Url::Url(base_url).host()),
         agents_(),
         sitemaps_(),
-        default_(agents_["*"])
+        default_(agents_.emplace("*", Agent(host_)).first->second)
     {
         std::string agent_name("*");
         std::istringstream input(content);
@@ -85,12 +91,12 @@ namespace Rep
                     {
                         for (auto other : group)
                         {
-                            agents_[other] = current->second;
+                            agents_.emplace(other, current->second);
                         }
                         group.clear();
                     }
                     agent_name = value;
-                    current = agents_.emplace(agent_name, Agent()).first;
+                    current = agents_.emplace(agent_name, Agent(host_)).first;
                 }
                 last_agent = true;
                 continue;
@@ -129,7 +135,7 @@ namespace Rep
         {
             for (auto other : group)
             {
-                agents_[other] = current->second;
+                agents_.emplace(other, current->second);
             }
         }
     }

--- a/test/test-agent.cpp
+++ b/test/test-agent.cpp
@@ -4,88 +4,114 @@
 
 TEST(AgentTest, Basic)
 {
-    Rep::Agent agent = Rep::Agent().allow("/").disallow("/foo");
+    Rep::Agent agent = Rep::Agent("a.com").allow("/").disallow("/foo");
     EXPECT_EQ(agent.directives().size(), 2);
 }
 
 TEST(AgentTest, ChecksAllowed)
 {
-    Rep::Agent agent = Rep::Agent().allow("/path");
+    Rep::Agent agent = Rep::Agent("a.com").allow("/path");
     EXPECT_TRUE(agent.allowed("/path"));
     EXPECT_TRUE(agent.allowed("/elsewhere"));
 }
 
+TEST(AgentTest, IgnoresExternalDisallow)
+{
+    Rep::Agent agent = Rep::Agent("a.com")
+        .allow("/path")
+        .disallow("http://b.com/external");
+    EXPECT_TRUE(agent.allowed("/path"));
+    EXPECT_TRUE(agent.allowed("/external"));
+}
+
+TEST(AgentTest, IgnoresExternalAllow)
+{
+    Rep::Agent agent = Rep::Agent("a.com")
+        .disallow("/path")
+        .allow("http://b.com/path/exception");
+    EXPECT_FALSE(agent.allowed("/path"));
+    EXPECT_FALSE(agent.allowed("/path/exception"));
+}
+
+TEST(AgentTest, NeverExternalAllowed)
+{
+    Rep::Agent agent = Rep::Agent("a.com");
+    EXPECT_FALSE(agent.allowed("http://b.com/"));
+}
+
 TEST(AgentTest, HonorsLongestFirstPriority)
 {
-    Rep::Agent agent = Rep::Agent().disallow("/path").allow("/path/exception");
+    Rep::Agent agent = Rep::Agent("a.com")
+        .disallow("/path")
+        .allow("/path/exception");
     EXPECT_TRUE(agent.allowed("/path/exception"));
     EXPECT_FALSE(agent.allowed("/path"));
 }
 
 TEST(AgentTest, RobotsTextAllowed)
 {
-    Rep::Agent agent = Rep::Agent().disallow("/robots.txt");
+    Rep::Agent agent = Rep::Agent("a.com").disallow("/robots.txt");
     EXPECT_TRUE(agent.allowed("/robots.txt"));
 }
 
 TEST(AgentTest, DisallowNone)
 {
-    Rep::Agent agent = Rep::Agent().disallow("");
+    Rep::Agent agent = Rep::Agent("a.com").disallow("");
     EXPECT_TRUE(agent.allowed("/anything"));
 }
 
 TEST(AgentTest, EscapedRule)
 {
-    Rep::Agent agent = Rep::Agent().disallow("/a%3cd.html");
+    Rep::Agent agent = Rep::Agent("a.com").disallow("/a%3cd.html");
     EXPECT_FALSE(agent.allowed("/a<d.html"));
     EXPECT_FALSE(agent.allowed("/a%3cd.html"));
 }
 
 TEST(AgentTest, UnescapedRule)
 {
-    Rep::Agent agent = Rep::Agent().disallow("/a<d.html");
+    Rep::Agent agent = Rep::Agent("a.com").disallow("/a<d.html");
     EXPECT_FALSE(agent.allowed("/a<d.html"));
     EXPECT_FALSE(agent.allowed("/a%3cd.html"));
 }
 
 TEST(AgentTest, EscapedRuleWildcard)
 {
-    Rep::Agent agent = Rep::Agent().disallow("/a%3c*");
+    Rep::Agent agent = Rep::Agent("a.com").disallow("/a%3c*");
     EXPECT_FALSE(agent.allowed("/a<d.html"));
     EXPECT_FALSE(agent.allowed("/a%3cd.html"));
 }
 
 TEST(AgentTest, UnescapedRuleWildcard)
 {
-    Rep::Agent agent = Rep::Agent().disallow("/a<*");
+    Rep::Agent agent = Rep::Agent("a.com").disallow("/a<*");
     EXPECT_FALSE(agent.allowed("/a<d.html"));
     EXPECT_FALSE(agent.allowed("/a%3cd.html"));
 }
 
 TEST(AgentTest, AcceptsFullUrl)
 {
-    Rep::Agent agent = Rep::Agent().disallow("/path;params?query");
+    Rep::Agent agent = Rep::Agent("a.com").disallow("/path;params?query");
     EXPECT_FALSE(agent.allowed(
         "http://userinfo@exmaple.com:10/path;params?query#fragment"));
 }
 
 TEST(AgentTest, QueryOnly)
 {
-    Rep::Agent agent = Rep::Agent().disallow("/?");
+    Rep::Agent agent = Rep::Agent("a.com").disallow("/?");
     EXPECT_TRUE(agent.allowed("/"));
     EXPECT_FALSE(agent.allowed("/?query"));
 }
 
 TEST(AgentTest, ParamsOnly)
 {
-    Rep::Agent agent = Rep::Agent().disallow("/;");
+    Rep::Agent agent = Rep::Agent("a.com").disallow("/;");
     EXPECT_TRUE(agent.allowed("/"));
     EXPECT_FALSE(agent.allowed("/;params"));
 }
 
 TEST(AgentTest, Str)
 {
-    Rep::Agent agent{};
+    Rep::Agent agent("a.com");
     agent.disallow("/foo");
     agent.allow("/bar");
     EXPECT_EQ("[Directive(Disallow: /foo), Directive(Allow: /bar)]", agent.str());

--- a/test/test-robots.cpp
+++ b/test/test-robots.cpp
@@ -289,3 +289,33 @@ TEST(RobotsTest, Str)
         " \"*\": [Directive(Allow: /foo), Directive(Disallow: /bar)]}",
         robot.str());
 }
+
+TEST(RobotsTest, IgnoresExternalDisallow)
+{
+    std::string content =
+        "User-agent: one\n"
+        "Allow: /path\n"
+        "Disallow: http://b.com/external\n";
+
+    Rep::Robots robot(content, "http://a.com/robots.txt");
+    EXPECT_TRUE(robot.allowed("/path", "one"));
+    EXPECT_TRUE(robot.allowed("/external", "one"));
+}
+
+TEST(RobotsTest, IgnoresExternalAllow)
+{
+    std::string content =
+        "User-agent: one\n"
+        "Disallow: /path\n"
+        "Allow: http://b.com/path/external\n";
+
+    Rep::Robots robot(content, "http://a.com/robots.txt");
+    EXPECT_FALSE(robot.allowed("/path", "one"));
+    EXPECT_FALSE(robot.allowed("/path/external", "one"));
+}
+
+TEST(RobotsTest, NeverExternalAllowed)
+{
+    Rep::Robots robot("", "http://a.com/robots.txt");
+    EXPECT_FALSE(robot.allowed("http://b.com/", "one"));
+}


### PR DESCRIPTION
This also changes behavior for the `Agent.allowed` method in that previously absolute URLs were only considered for the path regardless if the URL was part of this `robots.txt` or not. Now, if a `base_url` is passed to the `Robots` constructor or a `host` is passed to the `Agent` constructor all external URLs are disallowed. In practice, this path was not normally executed because in `reppy` we always lookup the `Robots` object *based* on the URL so only matching hosts would ever be considered.

Fixes #26.