### PR TITLE
Add back default constructor for Agent.

### DIFF
--- a/include/agent.h
+++ b/include/agent.h
@@ -31,6 +31,16 @@ namespace Rep
             directives_(), delay_(-1.0), sorted_(true), host_(host) {}
 
         /**
+         * Default copy constructor.
+         */
+        Agent(const Agent& rhs) = default;
+
+        /**
+         * Default move constructor.
+         */
+        Agent(Agent&& rhs) = default;
+
+        /**
          * Add an allowed directive.
          */
         Agent& allow(const std::string& query);
@@ -64,6 +74,11 @@ namespace Rep
         bool allowed(const std::string& path) const;
 
         std::string str() const;
+
+        /**
+         * Default copy assignment operator.
+         */
+        Agent& operator=(const Agent& rhs) = default;
 
     private:
         bool is_external(const Url::Url& url) const;

--- a/include/agent.h
+++ b/include/agent.h
@@ -20,6 +20,11 @@ namespace Rep
         typedef float delay_t;
 
         /**
+         * Default constructor
+         */
+        Agent() : Agent("") {}
+
+        /**
          * Construct an agent.
          */
         explicit Agent(const std::string& host) :

--- a/include/directive.h
+++ b/include/directive.h
@@ -19,10 +19,20 @@ namespace Rep
         Directive() = delete;
 
         /**
-         * The input to this constructor must be stripped of comments and trailing
-         * whitespace.
+         * The input to this constructor must be stripped of comments
+         * and trailing whitespace.
          */
         Directive(const std::string& line, bool allowed);
+
+        /**
+         * Default copy constructor.
+         */
+        Directive(const Directive& rhs) = default;
+
+        /**
+         * Default move constructor.
+         */
+        Directive(Directive&& rhs) = default;
 
         /**
          * The priority of the rule.
@@ -33,8 +43,8 @@ namespace Rep
         }
 
         /**
-         * Whether or not the provided path matches. The path is expected to be properly
-         * escaped.
+         * Whether or not the provided path matches. The path is
+         * expected to be properly escaped.
          */
         bool match(const std::string& path) const;
 
@@ -47,6 +57,11 @@ namespace Rep
         }
 
         std::string str() const;
+
+        /**
+         * Default copy assignment operator.
+         */
+        Directive& operator=(const Directive& rhs) = default;
 
     private:
         std::string expression_;


### PR DESCRIPTION
Previously, this was removed in #28, but the Cython bindings in `reppy` *really* want there to be a default constructor for `Agent`, so I'm adding it back for convenience.

Also, while I'm making changes, add copy and move constructors and explicit copy assignment operators for `Agent` and `Directive`. Currently, I don't believe these are used in the C++ code, but `reppy` uses the copy assignment operator for `Agent` which in turn
uses the copy assignment operator for `Directive`.