### PR TITLE
More wildcard tests

### DIFF
--- a/test/test-agent.cpp
+++ b/test/test-agent.cpp
@@ -60,6 +60,17 @@ TEST(AgentTest, DisallowNone)
     EXPECT_TRUE(agent.allowed("/anything"));
 }
 
+TEST(AgentTest, MiddleWildcard)
+{
+    Rep::Agent agent = Rep::Agent("a.com").disallow("/test*foo");
+    EXPECT_FALSE(agent.allowed("/testfoo"));
+    EXPECT_FALSE(agent.allowed("/testafoo"));
+    EXPECT_FALSE(agent.allowed("/testaasdffoo"));
+    EXPECT_FALSE(agent.allowed("/test/foo"));
+    EXPECT_TRUE(agent.allowed("/testfo"));
+    EXPECT_TRUE(agent.allowed("/estfoo"));
+}
+
 TEST(AgentTest, EscapedRule)
 {
     Rep::Agent agent = Rep::Agent("a.com").disallow("/a%3cd.html");

--- a/test/test-directive.cpp
+++ b/test/test-directive.cpp
@@ -70,6 +70,33 @@ TEST(DirectiveTest, WildcardTest)
     }
 }
 
+TEST(DirectiveTest, LeadingWildcard)
+{
+    std::vector<std::string> examples = {
+        "/test",
+        "/a/test",
+        "/ab/test",
+        "/abc/test",
+    };
+    std::string directive("*/test");
+    Rep::Directive parsed(directive, true);
+    for (auto example : examples)
+    {
+        EXPECT_TRUE(parsed.match(example)) <<
+            example << " didn't match " << directive;
+    }
+
+    std::vector<std::string> antiexamples = {
+        "/tes",
+        "/est",
+    };
+    for (auto example : antiexamples)
+    {
+        EXPECT_FALSE(parsed.match(example)) <<
+            example << " matched " << directive;
+    }
+}
+
 TEST(DirectiveTest, MultipleWildcardTest)
 {
     std::vector<std::string> examples = {


### PR DESCRIPTION
These tests were added as part of the initial investigation into #34, but don't directly address the issue reported there. It turns out the bug is *only* triggered when the wildcard is in the leading position and only occurs in the `Agent`, not in the `Directive`.

I have some separate failing tests that directly address the bug mentioned in #34, but I'm waiting to submit a PR until I have a fix.