### PR TITLE
coerce constant to a size_type to avoid compiler warning with gcc-7

### DIFF
--- a/test/test-agent.cpp
+++ b/test/test-agent.cpp
@@ -5,7 +5,8 @@
 TEST(AgentTest, Basic)
 {
     Rep::Agent agent = Rep::Agent("a.com").allow("/").disallow("/foo");
-    EXPECT_EQ(agent.directives().size(), 2);
+    auto expectedSize = static_cast<std::vector<Rep::Directive>::size_type>(2);
+    EXPECT_EQ(agent.directives().size(), expectedSize);
 }
 
 TEST(AgentTest, ChecksAllowed)


### PR DESCRIPTION
when compiling on ubuntu 16.04 w/ gcc-7, I get the following error:

```
~/rep-cpp$ make
g++ -Wall -Werror -std=c++11 -Iinclude/ -Ideps/url-cpp/include -Ideps/googletest/googletest/include -g -fprofile-arcs -ftest-coverage -O0 -fPIC -o test/test-agent.o -c test/test-agent.cpp
In file included from test/test-agent.cpp:1:0:
deps/googletest/googletest/include/gtest/gtest.h: In instantiation of ‘testing::AssertionResult testing::internal::CmpHelperEQ(const char*, const char*, const T1&, const T2&) [with T1 = long unsigned int; T2 = int]’:
deps/googletest/googletest/include/gtest/gtest.h:1421:23:   required from ‘static testing::AssertionResult testing::internal::EqHelper<lhs_is_null_literal>::Compare(const char*, const char*, const T1&, const T2&) [with T1 = long unsigned int; T2 = int; bool lhs_is_null_literal = false]’
test/test-agent.cpp:8:5:   required from here
deps/googletest/googletest/include/gtest/gtest.h:1392:11: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
   if (lhs == rhs) {
       ~~~~^~~~~~
cc1plus: all warnings being treated as errors
Makefile:47: recipe for target 'test/test-agent.o' failed
make: *** [test/test-agent.o] Error
```

There is some tangential drama about these warnings in googletest, but I found this was a simpler fix.