### PR TITLE
Bug/prefix wildcard with fullpath

### DIFF
--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -25,7 +25,7 @@ namespace Rep
         {
             return *this;
         }
-        directives_.push_back(Directive(escape_url(url), true));
+        directives_.push_back(Directive(url.defrag().escape().str(), true));
         sorted_ = false;
         return *this;
     }
@@ -45,7 +45,8 @@ namespace Rep
             {
                 return *this;
             }
-            directives_.push_back(Directive(escape_url(url), false));
+
+            directives_.push_back(Directive(url.defrag().escape().str(), false));
         }
         sorted_ = false;
         return *this;

--- a/test/test-robots.cpp
+++ b/test/test-robots.cpp
@@ -319,3 +319,21 @@ TEST(RobotsTest, NeverExternalAllowed)
     Rep::Robots robot("", "http://a.com/robots.txt");
     EXPECT_FALSE(robot.allowed("http://b.com/", "one"));
 }
+
+TEST(RobotsTest, PrefixStarExample)
+{
+    std::string content =
+        "# /robots.txt for fun and profit\n"
+        "\n"
+        "User-agent: ohmagad\n"
+        "Allow: /\n"
+        "Disallow: */dir\n"
+        "Disallow: /*/dir\n";
+    Rep::Robots robot(content);
+
+    // The ohmagad bot
+    EXPECT_TRUE(robot.allowed("/", "ohmagad"));
+    EXPECT_TRUE(robot.allowed("/a/b/page.html", "ohmagad"));
+    EXPECT_FALSE(robot.allowed("/dir/page.html", "ohmagad"));
+    EXPECT_FALSE(robot.allowed("/some/dir/page.html", "ohmagad"));
+}


### PR DESCRIPTION
It appears that the `escape_url` helper's call to `Url::fullpath` inserts forcibly a leading slash `/` to directives, which prevents a rule such as `Disallow: */bla` to work as expected.

In this PR, we simply don't call the `fullpath` method to circumvent the issue, but this could have been an other way (by patching the `fullpath` method, for example)