### PR TITLE
Updated googletest submodule to latest version and fixed compilation issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-dist: trusty
+dist: bionic
 git:
   submodules: true
 compiler:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BINARIES      =
 all: test release/librep.o $(BINARIES)
 
 $(GTEST_DIR)/libgtest.a:
-	g++ -isystem $(GTEST_DIR)/include -I$(GTEST_DIR) -pthread -c $(GTEST_DIR)/src/gtest-all.cc -o $(GTEST_DIR)/libgtest.a
+	g++ -std=c++11 -isystem $(GTEST_DIR)/include -I$(GTEST_DIR) -pthread -c $(GTEST_DIR)/src/gtest-all.cc -o $(GTEST_DIR)/libgtest.a
 
 # Release libraries
 release:
@@ -60,4 +60,4 @@ test: test-all
 	./scripts/check-coverage.sh $(PWD)
 
 clean:
-	rm -rf debug release test-all bench test/*.o deps/url-cpp/{debug,release}
+	rm -rf debug release test-all bench test/*.o test/*.gcda test/*.gcno deps/url-cpp/debug deps/url-cpp/release

--- a/test/test-agent.cpp
+++ b/test/test-agent.cpp
@@ -5,7 +5,7 @@
 TEST(AgentTest, Basic)
 {
     Rep::Agent agent = Rep::Agent("a.com").allow("/").disallow("/foo");
-    EXPECT_EQ(agent.directives().size(), 2);
+    EXPECT_EQ(agent.directives().size(), 2ul);
 }
 
 TEST(AgentTest, ChecksAllowed)


### PR DESCRIPTION
This PR is for the following changes:

1. Update the googletest submodule to the latest version. The current submodule version is two years old.
2. Fix the type mismatch in `test/test-agent.cpp` that was causing compilation to fail with gcc-7.4.
3. Update the Makefile 'clean` target to not use curly-brace list syntax as it does not execute as expected.
4. Update the Makefile `clean` target to remove the `.gcda` and `.gcno` gcov files from the `test` directory. 
5. Update Makefile to specify `-std=c++11` when compiling `libgtest.a`.
5. Update the Ubuntu distribution in `.travis.yaml` to `bionic` (18.04).