### PR TITLE
Revert "Bug/prefix wildcard with fullpath"

### DIFF
--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -25,7 +25,7 @@ namespace Rep
         {
             return *this;
         }
-        directives_.push_back(Directive(url.defrag().escape().str(), true));
+        directives_.push_back(Directive(escape_url(url), true));
         sorted_ = false;
         return *this;
     }
@@ -45,8 +45,7 @@ namespace Rep
             {
                 return *this;
             }
-
-            directives_.push_back(Directive(url.defrag().escape().str(), false));
+            directives_.push_back(Directive(escape_url(url), false));
         }
         sorted_ = false;
         return *this;

--- a/test/test-robots.cpp
+++ b/test/test-robots.cpp
@@ -319,21 +319,3 @@ TEST(RobotsTest, NeverExternalAllowed)
     Rep::Robots robot("", "http://a.com/robots.txt");
     EXPECT_FALSE(robot.allowed("http://b.com/", "one"));
 }
-
-TEST(RobotsTest, PrefixStarExample)
-{
-    std::string content =
-        "# /robots.txt for fun and profit\n"
-        "\n"
-        "User-agent: ohmagad\n"
-        "Allow: /\n"
-        "Disallow: */dir\n"
-        "Disallow: /*/dir\n";
-    Rep::Robots robot(content);
-
-    // The ohmagad bot
-    EXPECT_TRUE(robot.allowed("/", "ohmagad"));
-    EXPECT_TRUE(robot.allowed("/a/b/page.html", "ohmagad"));
-    EXPECT_FALSE(robot.allowed("/dir/page.html", "ohmagad"));
-    EXPECT_FALSE(robot.allowed("/some/dir/page.html", "ohmagad"));
-}


### PR DESCRIPTION
Reverts seomoz/rep-cpp#38

This implementation breaks the ability to correctly interpret the directive path for absolute URLs when the path domain matches the requested domain for `robots.txt`. 