### PR TITLE
Handle leading wildcard in directive path

### DIFF
--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <iomanip>
 #include <sstream>
+
 #include "url.h"
 
 #include "agent.h"
@@ -25,7 +26,6 @@ namespace Rep
 {
     Agent& Agent::allow(const std::string& query)
     {
-
         Url::Url url(query);
         // ignore directives for external URLs
         if (is_external(url))

--- a/test/test-robots.cpp
+++ b/test/test-robots.cpp
@@ -320,7 +320,25 @@ TEST(RobotsTest, NeverExternalAllowed)
     EXPECT_FALSE(robot.allowed("http://b.com/", "one"));
 }
 
-TEST(RobotsTest, LeadingWildcard)
+TEST(RobotsTest, LeadingWildcardAllow)
+{
+    std::string content =
+        "User-agent: meow\n"
+        "Disallow: /\n"
+        "Allow: ****/cats\n"
+        "Allow: */kangaroos\n";
+    Rep::Robots robot(content);
+
+    EXPECT_FALSE(robot.allowed("/kangaroo/zebra/cat/page.html", "meow"));
+    EXPECT_TRUE(robot.allowed("/cats.html", "meow"));
+    EXPECT_TRUE(robot.allowed("/cats/page.html", "meow"));
+    EXPECT_TRUE(robot.allowed("/get/more/cats/page.html", "meow"));
+    EXPECT_TRUE(robot.allowed("/kangaroos/page.html", "meow"));
+    EXPECT_TRUE(robot.allowed("/heaps/of/kangaroos/page.html", "meow"));
+    EXPECT_TRUE(robot.allowed("/kangaroosandkoalas/page.html", "meow"));
+}
+
+TEST(RobotsTest, LeadingWildcardDisallow)
 {
     std::string content =
         "User-agent: meow\n"
@@ -329,7 +347,6 @@ TEST(RobotsTest, LeadingWildcard)
         "Disallow: */kangaroos\n";
     Rep::Robots robot(content);
 
-    // The meow bot
     EXPECT_TRUE(robot.allowed("/kangaroo/zebra/cat/page.html", "meow"));
     EXPECT_FALSE(robot.allowed("/cats.html", "meow"));
     EXPECT_FALSE(robot.allowed("/cats/page.html", "meow"));

--- a/test/test-robots.cpp
+++ b/test/test-robots.cpp
@@ -319,3 +319,22 @@ TEST(RobotsTest, NeverExternalAllowed)
     Rep::Robots robot("", "http://a.com/robots.txt");
     EXPECT_FALSE(robot.allowed("http://b.com/", "one"));
 }
+
+TEST(RobotsTest, LeadingWildcard)
+{
+    std::string content =
+        "User-agent: meow\n"
+        "Allow: /\n"
+        "Disallow: ****/cats\n"
+        "Disallow: */kangaroos\n";
+    Rep::Robots robot(content);
+
+    // The meow bot
+    EXPECT_TRUE(robot.allowed("/kangaroo/zebra/cat/page.html", "meow"));
+    EXPECT_FALSE(robot.allowed("/cats.html", "meow"));
+    EXPECT_FALSE(robot.allowed("/cats/page.html", "meow"));
+    EXPECT_FALSE(robot.allowed("/get/more/cats/page.html", "meow"));
+    EXPECT_FALSE(robot.allowed("/kangaroos/page.html", "meow"));
+    EXPECT_FALSE(robot.allowed("/heaps/of/kangaroos/page.html", "meow"));
+    EXPECT_FALSE(robot.allowed("/kangaroosandkoalas/page.html", "meow"));
+}


### PR DESCRIPTION
This code considers one or more leading wildcard characters (`*`) as a special case in the `Agent` code. We push an additional directive to the `directives_` vector in the `Agent::Allow` and `Agent::Disallow` functions which is the result of evaluating the input query stripped of leading '*'s. That is, we evaluate e.g. `Disallow: */test` as `Disallow: /test` and `Disallow: /*/test`. 

Issue report here: https://github.com/seomoz/rep-cpp/issues/34