### PR TITLE
Offer fixes suggested by clang-tidy

### DIFF
--- a/include/agent.h
+++ b/include/agent.h
@@ -71,7 +71,7 @@ namespace Rep
         /**
          * Return true if the URL (either a full URL or a path) is allowed.
          */
-        bool allowed(const std::string& path) const;
+        bool allowed(const std::string& query) const;
 
         std::string str() const;
 

--- a/src/agent.cpp
+++ b/src/agent.cpp
@@ -1,6 +1,8 @@
 #include <algorithm>
 #include <iomanip>
 #include <sstream>
+#include <string>
+#include <vector>
 
 #include "url.h"
 
@@ -92,7 +94,7 @@ namespace Rep
         }
         std::string path(escape_url(url));
 
-        if (path.compare("/robots.txt") == 0)
+        if (path == "/robots.txt")
         {
             return true;
         }

--- a/src/robots.cpp
+++ b/src/robots.cpp
@@ -1,10 +1,14 @@
 #include <algorithm>
 #include <functional>
 #include <cctype>
+#include <cstddef>
+#include <exception>
 #include <locale>
 #include <sstream>
+#include <string>
 #include <iostream>
 #include <unordered_map>
+#include <vector>
 
 #include "url.h"
 
@@ -76,7 +80,7 @@ namespace Rep
         agent_map_t::iterator current = agents_.find("*");
         while (Robots::getpair(input, key, value))
         {
-            if (key.compare("user-agent") == 0)
+            if (key =="user-agent")
             {
                 // Store the user agent string as lowercased
                 std::transform(value.begin(), value.end(), value.begin(), ::tolower);
@@ -106,19 +110,19 @@ namespace Rep
                 last_agent = false;
             }
 
-            if (key.compare("sitemap") == 0)
+            if (key == "sitemap")
             {
                 sitemaps_.push_back(value);
             }
-            else if (key.compare("disallow") == 0)
+            else if (key == "disallow")
             {
                 current->second.disallow(value);
             }
-            else if (key.compare("allow") == 0)
+            else if (key == "allow")
             {
                 current->second.allow(value);
             }
-            else if (key.compare("crawl-delay") == 0)
+            else if (key == "crawl-delay")
             {
                 try
                 {


### PR DESCRIPTION
Mostly from `misc-include-cleaner`:

https://clang.llvm.org/extra/clang-tidy/checks/misc/include-cleaner.html

But also `readability-string-compare`:

https://clang.llvm.org/extra/clang-tidy/checks/readability/string-compare.html

And `readability-inconsistent-declaration-parameter-name`:

https://clang.llvm.org/extra/clang-tidy/checks/readability/inconsistent-declaration-parameter-name.html

c.f.

https://github.com/seomoz/rep-cpp/blob/ca2ae84bacb4a11471a7ce12946beada597713ee/src/agent.cpp#L86